### PR TITLE
Modify the display of the sign-in page

### DIFF
--- a/lib/live_web_server_web/components/layouts/app.html.heex
+++ b/lib/live_web_server_web/components/layouts/app.html.heex
@@ -58,6 +58,19 @@
       </dialog>
     </nav>
   <% end %>
+  <%= unless @current_administrator do %>
+    <nav id="live-web-server-header" class="flex ml-4">
+      <div class="flex flex-wrap content-center">
+        <span class="text-2xl font-bold mr-4">LiveWebServer Admin</span>
+      </div>
+      <div class="mt-1">
+        <div class="mt-1"></div>
+      </div>
+      <div class="flex flex-grow justify-end">
+        <button class="btn btn-neutral invisible"></button>
+      </div>
+    </nav>
+  <% end %>
 </header>
 <%= if Phoenix.Flash.get(@flash, :info) do %>
   <div id="flash-message" class="flash-message" phx-hook="FlashMessage">

--- a/lib/live_web_server_web/controllers/session_html/new.html.heex
+++ b/lib/live_web_server_web/controllers/session_html/new.html.heex
@@ -1,8 +1,5 @@
 <main class="w-full h-full min-h-screen bg-cover bg-center bg-fixed text-base-content">
   <div class="p-8 mx-auto md:w-2/3 lg:w-1/2 xl:w-1/3">
-    <div class="pt-8 pb-2 px-12 mx-auto mb-12 
-      bg-base-300 text-gray-800 shadow-neum border border-neum rounded-md flex flex-wrap">
-    </div>
     <.form for={@administrator} action="/sign_in">
       <div
         class="py-8 px-12 mx-auto mb-8 bg-base-300 text-gray-800 shadow-neum border border-neum rounded-md"


### PR DESCRIPTION
# Changes
* Remove unnecessary HTML elements from the Sign in page
* Display `LiveWebServer Admin` in the header section

# Review Perspective
* Whether the content of the implementation is appropriate
* The display position of `LiveWebServer Admin` is correct
![image](https://github.com/user-attachments/assets/2da22f50-b71a-4667-ae9c-3d1f04c3bd38)
